### PR TITLE
Add build step to justfile publish script

### DIFF
--- a/justfile
+++ b/justfile
@@ -43,6 +43,8 @@ publish-release revision='master':
   git clone https://github.com/raphjaph/ordapi.git tmp/release
   cd tmp/release
   git checkout {{ revision }}
+  bun install
+  bun run build
   bun publish
   cd ../..
   rm -rf tmp/release


### PR DESCRIPTION
I think this will fix #26 , because it mirrors what I have to do locally to fix the installation, but you may have to try publishing it to check. Basically, from what I understand, `bun publish` should be publishing the `dist/` directory which contains the output of the build script. 